### PR TITLE
Upgrade composer dependencies for Laravel 6.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.6",
     "plokko/firebase-php":"^0.1.1",
-    "illuminate/support": "^5.4.0|^6.0"
+    "illuminate/support": "^5.4.0|^6.0|^7.0"
   },
   "require-dev": {
     "orchestra/testbench": "~3.6.0",

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
   "require": {
     "php": ">=5.6",
     "plokko/firebase-php":"^0.1.1",
-    "illuminate/support": "^5.4.0"
+    "illuminate/support": "^5.4.0|^6.0"
   },
   "require-dev": {
     "orchestra/testbench": "~3.6.0",


### PR DESCRIPTION
Upgrade `illuminate/support` composer package to support `^6.0` versions of this package and so Laravel 6.0+ too. 